### PR TITLE
Fix Beacon AABB

### DIFF
--- a/src/main/java/guichaguri/betterfps/patches/block/FastBeacon.java
+++ b/src/main/java/guichaguri/betterfps/patches/block/FastBeacon.java
@@ -86,7 +86,7 @@ public abstract class FastBeacon extends TileEntityBeacon {
             }
 
             AxisAlignedBB box = new AxisAlignedBB(x, y, z, x + 1, y + 1, z + 1);
-            box = box.expand(radius, radius, radius).expand(0.0D, world.getHeight(), 0.0D);
+            box = box.grow(radius, radius, radius).expand(0.0D, world.getHeight(), 0.0D);
 
             for(EntityPlayer player : world.getEntitiesWithinAABB(EntityPlayer.class, box)) {
                 player.addPotionEffect(new PotionEffect(primaryEffect, effectTicks, effectLevel, true, true));


### PR DESCRIPTION
 This issue was described in #97 and should be fixed hereby.

Explanation:
The old Fastbeacon AABB expansion was wrong.
Expand only expands in 1 direction, to higher values with a positive value or to lower values with a negative value (so expand(1,1,1) makes the AABB Grow 1 towards the higher coordinates but stay the same towards the smaller coordinates).

Now it uses grow like in vanilla which increases the size in all directions. Just that vanilla uses grow(double) which calls grow(double, douoble, double) but this calls the second instantly so there's 1 function call less (not that it REALLY matters, the grow(double) would look cleaner).